### PR TITLE
Correct y_test log_data_ref name

### DIFF
--- a/model.py
+++ b/model.py
@@ -148,7 +148,7 @@ if __name__ == '__main__':
     tracking.log_data_ref(content=X_train, name='x_train')
     tracking.log_data_ref(content=y_train, name='y_train')
     tracking.log_data_ref(content=X_test, name='x_test')
-    tracking.log_data_ref(content=y_test, name='y_train')
+    tracking.log_data_ref(content=y_test, name='y_test')
 
     plx_callback = PolyaxonCallback()
     log_dir = tracking.get_tensorboard_path()


### PR DESCRIPTION
Following the quick start tutorial, I was surprised to see `y_train` twice in my input artifact. This minor change corrects the label to be `y_test`.